### PR TITLE
Update 1c_license_server.xml

### DIFF
--- a/1c_license_server.xml
+++ b/1c_license_server.xml
@@ -7,6 +7,11 @@
             <name>Templates (Kaminsoft)</name>
         </group>
     </groups>
+    <applications>
+      <application>
+        <name>[1С] Программные лицензии</name>
+      </application>
+    </applications>
     <templates>
         <template>
             <template>Template App 1C Enterprise License Server</template>


### PR DESCRIPTION
fix problem import
Error: Ошибка при импортировании
Элемент данных "[1С/Лицензии] Активные сеансы" в "Template App 1C Enterprise License Server": группа элементов данных "[1С] Программные лицензии" не существует.