### PR TITLE
Убраны кавычки для корректной работы awk в среде Windows

### DIFF
--- a/scripts/1c_license_server.sh
+++ b/scripts/1c_license_server.sh
@@ -101,7 +101,7 @@ function check_cluster_process {
 
     RAC_PARAM=$(echo "${1}" | sed 's/rmngr/manager/; s/rphost/process/')
     PROCESS_UUID=$(timeout -s HUP "${RAS_TIMEOUT}" rac "${RAC_PARAM}" list  --cluster "${2}"  ${RAS_AUTH} \
-        "$(awk -F# -v cluster="${2}" '$0 ~ cluster { print $1 }' "${CLSTR_CACHE}_"?("${RAS_PORTS//,/|}"))" 2>/dev/null | 
+        "$(awk -F# -v cluster="${2}" '$0 ~ cluster { print $1 }' ${CLSTR_CACHE}_?(${RAS_PORTS//,/|}))" 2>/dev/null | 
         awk -v FS=" +: *" -v filter="${RAC_PARAM}" '( $0 ~ "^("filter"|host|)( |$)" ) { print $2}' | 
         awk -v RS='' -v OFS=':' '$1=$1' | awk -F":" -v hostname="${HOSTNAME}" '( $0 ~ ":"hostname ) { print $1 }')
     if [[ -z ${PROCESS_UUID} ]]; then


### PR DESCRIPTION
Убраны кавычки в строке:
"${CLSTR_CACHE}_"?("${RAS_PORTS//,/|}")
т.к. в среде Windows awk выдает ошибку:
awk: fatal: cannot open file
 `/tmp/1c_clusters_cache_?(1545|52545|53545|51545|50545|54545)'
 for reading (No such file or directory)