### PR TITLE
Исправление в push_clusters_list - обработка оставшегося .lock-файла

### DIFF
--- a/scripts/1c_common_module.sh
+++ b/scripts/1c_common_module.sh
@@ -113,13 +113,17 @@ function push_clusters_uuid {
 # Сохранить список кластеров во временный файл
 function push_clusters_list {
 
-    if echo ${$} 2>/dev/null > "${CACHE_FILENAME}.lock"; then
-        trap 'rm -f "${CACHE_FILENAME}.lock"; exit ${?}' INT TERM EXIT
-        execute_tasks push_clusters_uuid "${@}" |
-        if [[ -z ${IS_WINDOWS} ]]; then cat; else iconv -f CP866 -t UTF-8; fi >| "${CACHE_FILENAME}"
-        rm -f "${CACHE_FILENAME}.lock"
-    fi
-
+	if [[ -f "${CACHE_FILENAME}.lock" ]]; then  
+		if   ps -p $(cat "${CACHE_FILENAME}.lock")  > /dev/null 2>&1; then
+			exit 1	
+	    fi 
+	fi
+    echo ${$} 2>/dev/null > "${CACHE_FILENAME}.lock"
+    trap 'rm -f "${CACHE_FILENAME}.lock"; exit ${?}' INT TERM EXIT
+    execute_tasks push_clusters_uuid "${@}" |
+    if [[ -z ${IS_WINDOWS} ]]; then cat; else iconv -f CP866 -t UTF-8; fi >| "${CACHE_FILENAME}"
+    rm -f "${CACHE_FILENAME}.lock"
+    
 }
 
 # Вывести список кластеров из временных файлов:

--- a/scripts/1c_common_module.sh
+++ b/scripts/1c_common_module.sh
@@ -113,11 +113,11 @@ function push_clusters_uuid {
 # Сохранить список кластеров во временный файл
 function push_clusters_list {
 
-	if [[ -f "${CACHE_FILENAME}.lock" ]]; then  
-		if   ps -p $(cat "${CACHE_FILENAME}.lock")  > /dev/null 2>&1; then
-			exit 1	
-	    fi 
-	fi
+    if [[ -f "${CACHE_FILENAME}.lock" ]]; then  
+	if   ps -p $(cat "${CACHE_FILENAME}.lock")  > /dev/null 2>&1; then
+	    exit 1	
+	fi 
+    fi
     echo ${$} 2>/dev/null > "${CACHE_FILENAME}.lock"
     trap 'rm -f "${CACHE_FILENAME}.lock"; exit ${?}' INT TERM EXIT
     execute_tasks push_clusters_uuid "${@}" |


### PR DESCRIPTION
trap в среде Windows не отрабатывает, поэтому если скрипт аварийно прекращает работу и остается .lock-файл - следующие запуски функции не удаляют .lock-файл и список кластеров не формируется. Поэтому добавлена проверка на наличие процесса с PID из .lock-файла.